### PR TITLE
Renamed ioStream_loopback to ioStream_pipe 

### DIFF
--- a/include/arch-common/cxa_ioStream_pipe.h
+++ b/include/arch-common/cxa_ioStream_pipe.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CXA_IOSTREAM_LOOPBACK_H_
-#define CXA_IOSTREAM_LOOPBACK_H_
+#ifndef CXA_IOSTREAM_PIPE_H_
+#define CXA_IOSTREAM_PIPE_H_
 
 
 /**
@@ -32,29 +32,36 @@
 
 
 // ******** global macro definitions ********
-#ifndef CXA_IOSTREAM_LOOPBACK_BUFFER_SIZE_BYTES
-	#define CXA_IOSTREAM_LOOPBACK_BUFFER_SIZE_BYTES				128
+#ifndef CXA_IOSTREAM_PIPE_BUFFER_SIZE_BYTES
+	#define CXA_IOSTREAM_PIPE_BUFFER_SIZE_BYTES				128
 #endif
 
 
 // ******** global type definitions *********
 /**
  * @public
- * @brief "Forward" declaration of the cxa_ioStream_loopback_t object
+ * @brief "Forward" declaration of the cxa_ioStream_pipe_t object
  */
-typedef struct cxa_ioStream_loopback cxa_ioStream_loopback_t;
+typedef struct cxa_ioStream_pipe cxa_ioStream_pipe_t;
 
 
-struct cxa_ioStream_loopback
+struct cxa_ioStream_pipe
 {
-	cxa_ioStream_t super;
+	cxa_ioStream_t endPoint1;
+	cxa_ioStream_t endPoint2;
 
-	cxa_fixedFifo_t fifo;
-	uint8_t fifo_raw[CXA_IOSTREAM_LOOPBACK_BUFFER_SIZE_BYTES];
+	cxa_fixedFifo_t fifo_ep1Read;
+	uint8_t fifo_ep1Read_raw[CXA_IOSTREAM_PIPE_BUFFER_SIZE_BYTES];
+
+	cxa_fixedFifo_t fifo_ep2Read;
+	uint8_t fifo_ep2Read_raw[CXA_IOSTREAM_PIPE_BUFFER_SIZE_BYTES];
 };
 
 
 // ******** global function prototypes ********
-void cxa_ioStream_loopback_init(cxa_ioStream_loopback_t *const ioStreamIn);
+void cxa_ioStream_pipe_init(cxa_ioStream_pipe_t *const ioStreamIn);
 
-#endif // CXA_IOSTREAM_LOOPBACK_H_
+cxa_ioStream_t* cxa_ioStream_pipe_getEndpoint1(cxa_ioStream_pipe_t* const ioStreamIn);
+cxa_ioStream_t* cxa_ioStream_pipe_getEndpoint2(cxa_ioStream_pipe_t* const ioStreamIn);
+
+#endif // CXA_IOSTREAM_PIPE_H_

--- a/src/arch-common/cxa_ioStream_loopback.c
+++ b/src/arch-common/cxa_ioStream_loopback.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 opencxa.org
+ * Copyright 2013-2015 opencxa.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,8 @@
 
 
 // ******** local function prototypes ********
-static cxa_ioStream_readStatus_t read_cb_ep1(uint8_t *const byteOut, void *const userVarIn);
-static bool write_cb_ep1(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn);
-static cxa_ioStream_readStatus_t read_cb_ep2(uint8_t *const byteOut, void *const userVarIn);
-static bool write_cb_ep2(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn);
+static cxa_ioStream_readStatus_t read_cb(uint8_t *const byteOut, void *const userVarIn);
+static bool write_cb(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn);
 
 
 // ********  local variable declarations *********
@@ -49,41 +47,26 @@ void cxa_ioStream_loopback_init(cxa_ioStream_loopback_t *const ioStreamIn)
 {
 	cxa_assert(ioStreamIn);
 
-	// initialize our ioStreams
-	cxa_ioStream_init(&ioStreamIn->endPoint1);
-	cxa_ioStream_bind(&ioStreamIn->endPoint1, read_cb_ep1, write_cb_ep1, (void*)ioStreamIn);
-	cxa_fixedFifo_initStd(&ioStreamIn->fifo_ep1Read, CXA_FF_ON_FULL_DROP, ioStreamIn->fifo_ep1Read_raw);
+	// initialize our fifo
+	cxa_fixedFifo_initStd(&ioStreamIn->fifo, CXA_FF_ON_FULL_DROP, ioStreamIn->fifo_raw);
 
-	cxa_ioStream_init(&ioStreamIn->endPoint2);
-	cxa_ioStream_bind(&ioStreamIn->endPoint2, read_cb_ep2, write_cb_ep2, (void*)ioStreamIn);
-	cxa_fixedFifo_initStd(&ioStreamIn->fifo_ep2Read, CXA_FF_ON_FULL_DROP, ioStreamIn->fifo_ep2Read_raw);
-}
-
-cxa_ioStream_t* cxa_ioStream_loopback_getEndpoint1(cxa_ioStream_loopback_t* const ioStreamIn)
-{
-	cxa_assert(ioStreamIn);
-	return &ioStreamIn->endPoint1;
-}
-
-
-cxa_ioStream_t* cxa_ioStream_loopback_getEndpoint2(cxa_ioStream_loopback_t* const ioStreamIn)
-{
-	cxa_assert(ioStreamIn);
-	return &ioStreamIn->endPoint2;
+	// initialize our super class
+	cxa_ioStream_init(&ioStreamIn->super);
+	cxa_ioStream_bind(&ioStreamIn->super, read_cb, write_cb, (void*)ioStreamIn);
 }
 
 
 // ******** local function implementations ********
-static cxa_ioStream_readStatus_t read_cb_ep1(uint8_t *const byteOut, void *const userVarIn)
+static cxa_ioStream_readStatus_t read_cb(uint8_t *const byteOut, void *const userVarIn)
 {
 	cxa_assert(userVarIn);
 	cxa_ioStream_loopback_t* ioStreamIn = (cxa_ioStream_loopback_t*)userVarIn;
 
-	return cxa_fixedFifo_dequeue(&ioStreamIn->fifo_ep1Read, byteOut) ? CXA_IOSTREAM_READSTAT_GOTDATA : CXA_IOSTREAM_READSTAT_NODATA;
+	return cxa_fixedFifo_dequeue(&ioStreamIn->fifo, byteOut) ? CXA_IOSTREAM_READSTAT_GOTDATA : CXA_IOSTREAM_READSTAT_NODATA;
 }
 
 
-static bool write_cb_ep1(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn)
+static bool write_cb(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn)
 {
 	cxa_assert(userVarIn);
 	cxa_ioStream_loopback_t* ioStreamIn = (cxa_ioStream_loopback_t*)userVarIn;
@@ -91,31 +74,7 @@ static bool write_cb_ep1(void* buffIn, size_t bufferSize_bytesIn, void *const us
 
 	for( size_t i = 0; i < bufferSize_bytesIn; i++ )
 	{
-		if( !cxa_fixedFifo_queue(&ioStreamIn->fifo_ep2Read, (void*)&(((uint8_t*)buffIn)[i])) ) return false;
-	}
-
-	return true;
-}
-
-
-static cxa_ioStream_readStatus_t read_cb_ep2(uint8_t *const byteOut, void *const userVarIn)
-{
-	cxa_assert(userVarIn);
-	cxa_ioStream_loopback_t* ioStreamIn = (cxa_ioStream_loopback_t*)userVarIn;
-
-	return cxa_fixedFifo_dequeue(&ioStreamIn->fifo_ep2Read, byteOut) ? CXA_IOSTREAM_READSTAT_GOTDATA : CXA_IOSTREAM_READSTAT_NODATA;
-}
-
-
-static bool write_cb_ep2(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn)
-{
-	cxa_assert(userVarIn);
-	cxa_ioStream_loopback_t* ioStreamIn = (cxa_ioStream_loopback_t*)userVarIn;
-	if( buffIn == NULL ) return false;
-
-	for( size_t i = 0; i < bufferSize_bytesIn; i++ )
-	{
-		if( !cxa_fixedFifo_queue(&ioStreamIn->fifo_ep1Read, (void*)&(((uint8_t*)buffIn)[i])) ) return false;
+		if( !cxa_fixedFifo_queue(&ioStreamIn->fifo, (void*)&(((uint8_t*)buffIn)[i])) ) return false;
 	}
 
 	return true;

--- a/src/arch-common/cxa_ioStream_pipe.c
+++ b/src/arch-common/cxa_ioStream_pipe.c
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2013-2015 opencxa.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cxa_ioStream_pipe.h"
+
+
+/**
+ * @author Christopher Armenio
+ */
+
+
+// ******** includes ********
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <cxa_assert.h>
+
+
+// ******** local macro definitions ********
+
+
+// ******** local type definitions ********
+
+
+// ******** local function prototypes ********
+static cxa_ioStream_readStatus_t read_cb_ep1(uint8_t *const byteOut, void *const userVarIn);
+static bool write_cb_ep1(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn);
+static cxa_ioStream_readStatus_t read_cb_ep2(uint8_t *const byteOut, void *const userVarIn);
+static bool write_cb_ep2(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn);
+
+
+// ********  local variable declarations *********
+
+
+// ******** global function implementations ********
+void cxa_ioStream_pipe_init(cxa_ioStream_pipe_t *const ioStreamIn)
+{
+	cxa_assert(ioStreamIn);
+
+	// initialize our ioStreams
+	cxa_ioStream_init(&ioStreamIn->endPoint1);
+	cxa_ioStream_bind(&ioStreamIn->endPoint1, read_cb_ep1, write_cb_ep1, (void*)ioStreamIn);
+	cxa_fixedFifo_initStd(&ioStreamIn->fifo_ep1Read, CXA_FF_ON_FULL_DROP, ioStreamIn->fifo_ep1Read_raw);
+
+	cxa_ioStream_init(&ioStreamIn->endPoint2);
+	cxa_ioStream_bind(&ioStreamIn->endPoint2, read_cb_ep2, write_cb_ep2, (void*)ioStreamIn);
+	cxa_fixedFifo_initStd(&ioStreamIn->fifo_ep2Read, CXA_FF_ON_FULL_DROP, ioStreamIn->fifo_ep2Read_raw);
+}
+
+cxa_ioStream_t* cxa_ioStream_pipe_getEndpoint1(cxa_ioStream_pipe_t* const ioStreamIn)
+{
+	cxa_assert(ioStreamIn);
+	return &ioStreamIn->endPoint1;
+}
+
+
+cxa_ioStream_t* cxa_ioStream_pipe_getEndpoint2(cxa_ioStream_pipe_t* const ioStreamIn)
+{
+	cxa_assert(ioStreamIn);
+	return &ioStreamIn->endPoint2;
+}
+
+
+// ******** local function implementations ********
+static cxa_ioStream_readStatus_t read_cb_ep1(uint8_t *const byteOut, void *const userVarIn)
+{
+	cxa_assert(userVarIn);
+	cxa_ioStream_pipe_t* ioStreamIn = (cxa_ioStream_pipe_t*)userVarIn;
+
+	return cxa_fixedFifo_dequeue(&ioStreamIn->fifo_ep1Read, byteOut) ? CXA_IOSTREAM_READSTAT_GOTDATA : CXA_IOSTREAM_READSTAT_NODATA;
+}
+
+
+static bool write_cb_ep1(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn)
+{
+	cxa_assert(userVarIn);
+	cxa_ioStream_pipe_t* ioStreamIn = (cxa_ioStream_pipe_t*)userVarIn;
+	if( buffIn == NULL ) return false;
+
+	for( size_t i = 0; i < bufferSize_bytesIn; i++ )
+	{
+		if( !cxa_fixedFifo_queue(&ioStreamIn->fifo_ep2Read, (void*)&(((uint8_t*)buffIn)[i])) ) return false;
+	}
+
+	return true;
+}
+
+
+static cxa_ioStream_readStatus_t read_cb_ep2(uint8_t *const byteOut, void *const userVarIn)
+{
+	cxa_assert(userVarIn);
+	cxa_ioStream_pipe_t* ioStreamIn = (cxa_ioStream_pipe_t*)userVarIn;
+
+	return cxa_fixedFifo_dequeue(&ioStreamIn->fifo_ep2Read, byteOut) ? CXA_IOSTREAM_READSTAT_GOTDATA : CXA_IOSTREAM_READSTAT_NODATA;
+}
+
+
+static bool write_cb_ep2(void* buffIn, size_t bufferSize_bytesIn, void *const userVarIn)
+{
+	cxa_assert(userVarIn);
+	cxa_ioStream_pipe_t* ioStreamIn = (cxa_ioStream_pipe_t*)userVarIn;
+	if( buffIn == NULL ) return false;
+
+	for( size_t i = 0; i < bufferSize_bytesIn; i++ )
+	{
+		if( !cxa_fixedFifo_queue(&ioStreamIn->fifo_ep1Read, (void*)&(((uint8_t*)buffIn)[i])) ) return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
(which is actually the correct terminology based upon its functionality). Implemented a true ioStream_loopback.

Closes #2 
