### PR TITLE
POSIX - employ the use of cfmakeraw()

### DIFF
--- a/src/arch-posix/cxa_posix_usart.c
+++ b/src/arch-posix/cxa_posix_usart.c
@@ -116,6 +116,7 @@ static bool set_interface_attribs (int fd, int speed, int parity)
 	tty.c_cflag &= ~CSTOPB;
 	tty.c_cflag &= ~CRTSCTS;
 
+	cfmakeraw(&tty);                // make raw connection
 	if (tcsetattr (fd, TCSANOW, &tty) != 0) false;
 	return true;
 }


### PR DESCRIPTION
 in order to allow raw binary serial communication without terminal emulation.

Fixes 0x13 getting reporting as 0x10 when pulled from the byte stream.

Testing the PR functionality of Github as well with an easy one here.